### PR TITLE
[add] prettier precommit hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,26 +1,33 @@
 {
-  "name": "sprk",
-  "version": "1.0.0",
-  "main": "index.js",
-  "license": "MIT",
-  "scripts": {
-    "start": "nodemon index.js --ignore 'storage'"
-  },
-  "dependencies": {
-    "cron": "^1.6.0",
-    "date-fns": "^1.30.1",
-    "express": "^4.16.4",
-    "lowdb": "^1.0.0",
-    "multer": "^1.4.1",
-    "valid-url": "^1.0.9",
-    "winston": "^3.2.1"
-  },
-  "devDependencies": {
-    "eslint": "^6.5.1",
-    "eslint-config-prettier": "^6.3.0",
-    "eslint-plugin-prettier": "^3.1.1",
-    "lorem-ipsum": "^1.0.6",
-    "nodemon": "^1.18.10",
-    "prettier": "^1.18.2"
-  }
+    "name": "sprk",
+    "version": "1.0.0",
+    "main": "index.js",
+    "license": "MIT",
+    "scripts": {
+        "start": "nodemon index.js --ignore 'storage'"
+    },
+    "husky": {
+        "hooks": {
+            "pre-commit": "pretty-quick --staged"
+        }
+    },
+    "dependencies": {
+        "cron": "^1.6.0",
+        "date-fns": "^1.30.1",
+        "express": "^4.16.4",
+        "lowdb": "^1.0.0",
+        "multer": "^1.4.1",
+        "valid-url": "^1.0.9",
+        "winston": "^3.2.1"
+    },
+    "devDependencies": {
+        "eslint": "^6.5.1",
+        "eslint-config-prettier": "^6.3.0",
+        "eslint-plugin-prettier": "^3.1.1",
+        "husky": "^3.0.8",
+        "lorem-ipsum": "^1.0.6",
+        "nodemon": "^1.18.10",
+        "prettier": "^1.18.2",
+        "pretty-quick": "^1.11.1"
+    }
 }


### PR DESCRIPTION
Helpful if person we are collaborating with doesnt have prettier installed and format on save enabled,
this acts as fallback making sure code is always formatted before commit no matter what